### PR TITLE
Fixes build/test scripts that currently fail on a clean npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metal-css-transitions",
   "description": "Metal component used to apply css transitions",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "license": "BSD",
   "repository": "bryceosterhaus/metal-css-transitions",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -33,14 +33,13 @@
   },
   "dependencies": {
     "metal-anim": "^2.0.0",
-    "metal-dom": "^2.2.3",
-    "metal-jsx": "^2.2.5"
+    "metal-dom": "^2.5.1",
+    "metal-jsx": "^2.5.1"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
-    "babel-preset-metal": "^4.0.1",
+    "babel-preset-metal-jsx": "^0.0.3",
     "gulp": "^3.9.1",
-    "gulp-metal": "^1.7.5",
-    "metal": "^2.2.3"
+    "gulp-metal": "^1.9.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metal-css-transitions",
   "description": "Metal component used to apply css transitions",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "BSD",
   "repository": "bryceosterhaus/metal-css-transitions",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
+    "babel-preset-metal": "^4.1.0",
     "babel-preset-metal-jsx": "^0.0.3",
     "gulp": "^3.9.1",
     "gulp-metal": "^1.9.10"


### PR DESCRIPTION
I've just done a clean npm install in metal-css-transitions and got an error due to this missing preset, so just adding it back :)